### PR TITLE
Allow multipliers in {size=<value>}

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1184,6 +1184,8 @@ class Layout(object):
 
                     if value[0] in "+-":
                         push().size += int(value)
+                    elif value[0] == "*":
+                        push().size = int(float(value[1:]) * push().size)
                     else:
                         push().size = int(value)
 


### PR DESCRIPTION
Sometimes, your tag doesn't know what size it will be, but `+`/`-` is not enough, and turned out that in some circumstances I actually need a multiplier, rather than an addition, never mind that it's an int in the end.

Could this be added?

```
"{size=*2}This is double size{/size} and this is {size=*0.5}half size{/size}"
```